### PR TITLE
bump version to v0.14.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: test & coverage report creation
+        # Some tests, notably TestRandomOperations, are extremely slow in CI
+        # with the race detector enabled, so we use -short when -race is
+        # enabled to reduce the number of slow tests, and then run without
+        # -short with -race disabled for a larger test set.
+        #
+        # We still run the same tests, just on smaller data sets with -short.
         run: |
-          go test ./... -mod=readonly -timeout 8m -race -coverprofile=coverage.txt -covermode=atomic
+          go test ./... -mod=readonly -timeout 5m -short -race -coverprofile=coverage.txt -covermode=atomic
+          go test ./... -mod=readonly -timeout 5m
       - uses: codecov/codecov-action@v1
         with:
           file: ./coverage.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,17 +1,17 @@
 name: Lint
-on: 
+on:
   pull_request:
   push:
-    branches: 
+    branches:
       - master
 jobs:
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@master
+      - uses: golangci/golangci-lint-action@v2.3.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.27
+          version: v1.32
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,9 @@ linters:
 
 issues:
   exclude-rules:
+    - path: _test\.go
+      linters:
+        - gosec
     - linters:
         - lll
       source: "https://"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.14.3 (November 23, 2020)
+
+Special thanks to external contributors on this release: @klim0v
+
+### Bug Fixes
+
+- [\#324](https://github.com/cosmos/iavl/pull/324) Fix `DeleteVersions` not properly removing
+  orphans, and add `DeleteVersionsRange` to delete a range.
+
+## 0.14.2 (October 12, 2020)
+
+### Bug Fixes
+
+- [\#318](https://github.com/cosmos/iavl/pull/318) Fix constant overflow when compiling for 32bit machines.
+
 ## 0.14.1 (October 9, 2020)
 
 ### Improvements

--- a/basic_test.go
+++ b/basic_test.go
@@ -149,7 +149,7 @@ func TestUnit(t *testing.T) {
 		tree.root = origNode
 	}
 
-	//////// Test Set cases:
+	// Test Set cases:
 
 	// Case 1:
 	t1 := T(N(4, 20))
@@ -172,7 +172,7 @@ func TestUnit(t *testing.T) {
 	expectSet(t4, 8, "(((1 2) (5 6)) ((7 8) 9))", 5)
 	expectSet(t4, 10, "(((1 2) (5 6)) (7 (9 10)))", 5)
 
-	//////// Test Remove cases:
+	// Test Remove cases:
 
 	t10 := T(N(N(1, 2), 3))
 

--- a/common/bytes.go
+++ b/common/bytes.go
@@ -25,7 +25,7 @@ func (bz HexBytes) MarshalJSON() ([]byte, error) {
 	s := strings.ToUpper(hex.EncodeToString(bz))
 	jbz := make([]byte, len(s)+2)
 	jbz[0] = '"'
-	copy(jbz[1:], []byte(s))
+	copy(jbz[1:], s)
 	jbz[len(jbz)-1] = '"'
 	return jbz, nil
 }

--- a/common/random.go
+++ b/common/random.go
@@ -47,7 +47,7 @@ func (r *Rand) init() {
 }
 
 func (r *Rand) reset(seed int64) {
-	r.rand = mrand.New(mrand.NewSource(seed))
+	r.rand = mrand.New(mrand.NewSource(seed)) // nolint:gosec // G404: Use of weak random number generator
 }
 
 //----------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/tendermint/go-amino v0.14.1
 	github.com/tendermint/tendermint v0.33.5
-	github.com/tendermint/tm-db v0.5.1
+	github.com/tendermint/tm-db v0.5.2
 	golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
+github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
@@ -41,6 +42,7 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
@@ -344,6 +346,8 @@ github.com/tendermint/tendermint v0.33.5 h1:jYgRd9ImkzA9iOyhpmgreYsqSB6tpDa6/rXY
 github.com/tendermint/tendermint v0.33.5/go.mod h1:0yUs9eIuuDq07nQql9BmI30FtYGcEC60Tu5JzB5IezM=
 github.com/tendermint/tm-db v0.5.1 h1:H9HDq8UEA7Eeg13kdYckkgwwkQLBnJGgX4PgLJRhieY=
 github.com/tendermint/tm-db v0.5.1/go.mod h1:g92zWjHpCYlEvQXvy9M168Su8V1IBEeawpXVVBaK4f4=
+github.com/tendermint/tm-db v0.5.2 h1:QG3IxQZBubWlr7kGQcYIavyTNmZRO+r//nENxoq0g34=
+github.com/tendermint/tm-db v0.5.2/go.mod h1:VrPTx04QJhQ9d8TFUTc2GpPBvBf/U9vIdBIzkjBk7Lk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -354,6 +358,8 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/bbolt v1.3.4 h1:hi1bXHMVrlQh6WwxAy+qZCV/SYIlqo+Ushwdpa4tAKg=
+go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
@@ -431,6 +437,7 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -478,6 +485,7 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.28.1/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
+google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -530,23 +530,51 @@ func (tree *MutableTree) SetInitialVersion(version uint64) {
 	tree.ndb.opts.InitialVersion = version
 }
 
-// DeleteVersions deletes a series of versions from the MutableTree. An error
-// is returned if any single version is invalid or the delete fails. All writes
-// happen in a single batch with a single commit.
+// DeleteVersions deletes a series of versions from the MutableTree.
+// Deprecated: please use DeleteVersionsRange instead.
 func (tree *MutableTree) DeleteVersions(versions ...int64) error {
 	debug("DELETING VERSIONS: %v\n", versions)
 
+	if len(versions) == 0 {
+		return nil
+	}
+
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i] < versions[j]
+	})
+
+	// Find ordered data and delete by interval
+	intervals := map[int64]int64{}
+	var fromVersion int64
 	for _, version := range versions {
-		if err := tree.deleteVersion(version); err != nil {
+		if version-fromVersion != intervals[fromVersion] {
+			fromVersion = version
+		}
+		intervals[fromVersion]++
+	}
+
+	for fromVersion, sortedBatchSize := range intervals {
+		if err := tree.DeleteVersionsRange(fromVersion, fromVersion+sortedBatchSize); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// DeleteVersionsRange removes versions from an interval from the MutableTree (not inclusive).
+// An error is returned if any single version has active readers.
+// All writes happen in a single batch with a single commit.
+func (tree *MutableTree) DeleteVersionsRange(fromVersion, toVersion int64) error {
+	if err := tree.ndb.DeleteVersionsRange(fromVersion, toVersion); err != nil {
+		return err
 	}
 
 	if err := tree.ndb.Commit(); err != nil {
 		return err
 	}
 
-	for _, version := range versions {
+	for version := fromVersion; version < toVersion; version++ {
 		delete(tree.versions, version)
 	}
 

--- a/proof_range.go
+++ b/proof_range.go
@@ -303,8 +303,6 @@ func (proof *RangeProof) _computeRootHash() (rootHash []byte, treeEnd bool, err 
 	return rootHash, treeEnd, nil
 }
 
-///////////////////////////////////////////////////////////////////////////////
-
 // keyStart is inclusive and keyEnd is exclusive.
 // If keyStart or keyEnd don't exist, the leaf before keyStart
 // or after keyEnd will also be included, but not be included in values.

--- a/repair.go
+++ b/repair.go
@@ -41,7 +41,7 @@ func Repair013Orphans(db dbm.DB) (uint64, error) {
 	)
 	batch := db.NewBatch()
 	defer batch.Close()
-	ndb.traverseRange(orphanKeyFormat.Key(version), orphanKeyFormat.Key(math.MaxInt64), func(k, v []byte) {
+	ndb.traverseRange(orphanKeyFormat.Key(version), orphanKeyFormat.Key(int64(math.MaxInt64)), func(k, v []byte) {
 		// Sanity check so we don't remove stuff we shouldn't
 		var toVersion int64
 		orphanKeyFormat.Scan(k, &toVersion)

--- a/tree_fuzz_test.go
+++ b/tree_fuzz_test.go
@@ -88,7 +88,7 @@ func genRandomProgram(size int) *program {
 	for p.size() < size {
 		k, v := []byte(cmn.RandStr(1)), []byte(cmn.RandStr(1))
 
-		switch rand.Int() % 7 { //nolint: gosec // Turn off gosec here because this is for testing
+		switch rand.Int() % 7 {
 		case 0, 1, 2:
 			p.addInstruction(instruction{op: "SET", k: k, v: v})
 		case 3, 4:
@@ -97,7 +97,7 @@ func genRandomProgram(size int) *program {
 			p.addInstruction(instruction{op: "SAVE", version: int64(nextVersion)})
 			nextVersion++
 		case 6:
-			if rv := rand.Int() % nextVersion; rv < nextVersion && rv > 0 { //nolint: gosec // Turn off gosec here because this is for testing
+			if rv := rand.Int() % nextVersion; rv < nextVersion && rv > 0 {
 				p.addInstruction(instruction{op: "DELETE", version: int64(rv)})
 			}
 		}

--- a/tree_random_test.go
+++ b/tree_random_test.go
@@ -15,20 +15,28 @@ import (
 )
 
 func TestRandomOperations(t *testing.T) {
+	// In short mode (specifically, when running in CI with the race detector),
+	// we only run the first couple of seeds.
 	seeds := []int64{
-		49872768941,
+		498727689,
 		756509998,
 		480459882,
-		32473644,
+		324736440,
 		581827344,
 		470870060,
 		390970079,
 		846023066,
+		518638291,
+		957382170,
 	}
 
-	for _, seed := range seeds {
-		seed := seed
+	for i, seed := range seeds {
+		i, seed := i, seed
 		t.Run(fmt.Sprintf("Seed %v", seed), func(t *testing.T) {
+			if testing.Short() && i >= 2 {
+				t.Skip("Skipping seed in short mode")
+			}
+			t.Parallel() // comment out to disable parallel tests, or use -parallel 1
 			testRandomOperations(t, seed)
 		})
 	}
@@ -41,13 +49,16 @@ func testRandomOperations(t *testing.T, randSeed int64) {
 		keySize   = 16 // before base64-encoding
 		valueSize = 16 // before base64-encoding
 
-		versions     = 32   // number of final versions to generate
-		reloadChance = 0.1  // chance of tree reload after save
-		deleteChance = 0.2  // chance of random version deletion after save
-		revertChance = 0.05 // chance to revert tree to random version with LoadVersionForOverwriting
-		syncChance   = 0.2  // chance of enabling sync writes on tree load
-		cacheChance  = 0.4  // chance of enabling caching
-		cacheSizeMax = 256  // maximum size of cache (will be random from 1)
+		versions          = 32   // number of final versions to generate
+		reloadChance      = 0.1  // chance of tree reload after save
+		deleteChance      = 0.2  // chance of random version deletion after save
+		deleteRangeChance = 0.3  // chance of deleting a version range (DeleteVersionsRange)
+		deleteMultiChance = 0.3  // chance of deleting multiple versions (DeleteVersions)
+		deleteMax         = 5    // max number of versions to delete
+		revertChance      = 0.05 // chance to revert tree to random version with LoadVersionForOverwriting
+		syncChance        = 0.2  // chance of enabling sync writes on tree load
+		cacheChance       = 0.4  // chance of enabling caching
+		cacheSizeMax      = 256  // maximum size of cache (will be random from 1)
 
 		versionOps  = 64  // number of operations (create/update/delete) per version
 		updateRatio = 0.4 // ratio of updates out of all operations
@@ -144,11 +155,52 @@ func testRandomOperations(t *testing.T, randSeed int64) {
 		// Save the mirror as a disk mirror, since we currently persist all versions.
 		diskMirrors[version] = copyMirror(mirror)
 
-		// Delete a random version if requested, but never the latest version.
+		// Delete random versions if requested, but never the latest version.
 		if r.Float64() < deleteChance {
 			versions := getMirrorVersions(diskMirrors, memMirrors)
-			if len(versions) > 2 {
-				deleteVersion := int64(versions[r.Intn(len(versions)-1)])
+			switch {
+			case len(versions) < 2:
+
+			case r.Float64() < deleteRangeChance:
+				indexFrom := r.Intn(len(versions) - 1)
+				from := versions[indexFrom]
+				batch := r.Intn(deleteMax)
+				if batch > len(versions[indexFrom:])-2 {
+					batch = len(versions[indexFrom:]) - 2
+				}
+				to := versions[indexFrom+batch] + 1
+				t.Logf("Deleting versions %v-%v", from, to-1)
+				err = tree.DeleteVersionsRange(int64(from), int64(to))
+				require.NoError(t, err)
+				for version := from; version < to; version++ {
+					delete(diskMirrors, int64(version))
+					delete(memMirrors, int64(version))
+				}
+
+			// adjust probability to take into account probability of range delete not happening
+			case r.Float64() < deleteMultiChance/(1.0-deleteRangeChance):
+				deleteVersions := []int64{}
+				desc := ""
+				batchSize := 1 + r.Intn(deleteMax)
+				if batchSize > len(versions)-1 {
+					batchSize = len(versions) - 1
+				}
+				for _, i := range r.Perm(len(versions) - 1)[:batchSize] {
+					deleteVersions = append(deleteVersions, int64(versions[i]))
+					delete(diskMirrors, int64(versions[i]))
+					delete(memMirrors, int64(versions[i]))
+					if len(desc) > 0 {
+						desc += ","
+					}
+					desc += fmt.Sprintf("%v", versions[i])
+				}
+				t.Logf("Deleting versions %v", desc)
+				err = tree.DeleteVersions(deleteVersions...)
+				require.NoError(t, err)
+
+			default:
+				i := r.Intn(len(versions) - 1)
+				deleteVersion := int64(versions[i])
 				t.Logf("Deleting version %v", deleteVersion)
 				err = tree.DeleteVersion(deleteVersion)
 				require.NoError(t, err)
@@ -212,20 +264,90 @@ func testRandomOperations(t *testing.T, randSeed int64) {
 	// removed, and check that the latest versions matches the mirror.
 	remaining := tree.AvailableVersions()
 	remaining = remaining[:len(remaining)-1]
-	for len(remaining) > 0 {
-		i := r.Intn(len(remaining))
-		deleteVersion := int64(remaining[i])
-		remaining = append(remaining[:i], remaining[i+1:]...)
-		t.Logf("Deleting version %v", deleteVersion)
-		err = tree.DeleteVersion(deleteVersion)
-		require.NoError(t, err)
-	}
-	require.EqualValues(t, []int{int(version)}, tree.AvailableVersions())
 
+	switch {
+	case len(remaining) == 0:
+
+	case r.Float64() < deleteRangeChance:
+		t.Logf("Deleting versions %v-%v", remaining[0], remaining[len(remaining)-1])
+		err = tree.DeleteVersionsRange(int64(remaining[0]), int64(remaining[len(remaining)-1]+1))
+		require.NoError(t, err)
+
+	// adjust probability to take into account probability of range delete not happening
+	case r.Float64() < deleteMultiChance/(1.0-deleteRangeChance):
+		deleteVersions := []int64{}
+		desc := ""
+		for _, i := range r.Perm(len(remaining)) {
+			deleteVersions = append(deleteVersions, int64(remaining[i]))
+			if len(desc) > 0 {
+				desc += ","
+			}
+			desc += fmt.Sprintf("%v", remaining[i])
+		}
+		t.Logf("Deleting versions %v", desc)
+		err = tree.DeleteVersions(deleteVersions...)
+		require.NoError(t, err)
+
+	default:
+		for len(remaining) > 0 {
+			i := r.Intn(len(remaining))
+			deleteVersion := int64(remaining[i])
+			remaining = append(remaining[:i], remaining[i+1:]...)
+			t.Logf("Deleting version %v", deleteVersion)
+			err = tree.DeleteVersion(deleteVersion)
+			require.NoError(t, err)
+		}
+	}
+
+	require.EqualValues(t, []int{int(version)}, tree.AvailableVersions())
 	assertMirror(t, tree, mirror, version)
 	assertMirror(t, tree, mirror, 0)
 	assertOrphans(t, tree, 0)
 	t.Logf("Final version %v is correct, with no stray orphans", version)
+
+	// Now, let's delete all remaining key/value pairs, and make sure no stray
+	// data is left behind in the database.
+	prevVersion := tree.Version()
+	keys := [][]byte{}
+	tree.Iterate(func(key, value []byte) bool {
+		keys = append(keys, key)
+		return false
+	})
+	for _, key := range keys {
+		_, removed := tree.Remove(key)
+		require.True(t, removed)
+	}
+	_, _, err = tree.SaveVersion()
+	require.NoError(t, err)
+	err = tree.DeleteVersion(prevVersion)
+	require.NoError(t, err)
+	assertEmptyDatabase(t, tree)
+	t.Logf("Final version %v deleted, no stray database entries", prevVersion)
+}
+
+// Checks that the database is empty, only containing a single root entry
+// at the given version.
+func assertEmptyDatabase(t *testing.T, tree *MutableTree) {
+	version := tree.Version()
+	iter, err := tree.ndb.db.Iterator(nil, nil)
+	require.NoError(t, err)
+
+	var (
+		firstKey []byte
+		count    int
+	)
+	for ; iter.Valid(); iter.Next() {
+		count++
+		if firstKey == nil {
+			firstKey = iter.Key()
+		}
+	}
+	require.NoError(t, iter.Error())
+	require.EqualValues(t, 1, count, "Found %v database entries, expected 1", count)
+
+	var foundVersion int64
+	rootKeyFormat.Scan(firstKey, &foundVersion)
+	require.Equal(t, version, foundVersion, "Unexpected root version")
 }
 
 // Checks that the tree has the given number of orphan nodes.


### PR DESCRIPTION
* fix: constant overflow when compiling for 32bit machines (#318)

on Go 1.x(x) all constants are ints by default which causing
build for 32bit machines to fail due to overflow
https://github.com/golang/go/issues/23086

Signed-off-by: Artur Troian <troian.ap@gmail.com>

* changelog: release 0.14.2

* lint: update golangci-lint to 1.29 (#297)

* ci: freeze golangci action version (#303)

* github: bump golangci-lint and fix linter issues (#325)

* test: check stray database entries in TestRandomOperations (#326)

Checks that we don't leave behind any junk in the database, as reported in #324.

* revert Protobuf methods accidentally cherry-picked in a41e36b

* go.mod: bump tm-db to 0.5.2

* fix DeleteVersions stray orphans, and add DeleteVersionsRange (#324)

* test: add TestRandomOperations case for DeleteVersions

* test: run slow tests without race detector in CI (#338)

* changelog: release 0.14.3 (#333)

Co-authored-by: Artur Troian <troian@users.noreply.github.com>
Co-authored-by: Erik Grinaker <erik@interchain.berlin>
Co-authored-by: Marko <marbar3778@yahoo.com>
Co-authored-by: Klimov Sergey <klim0v-sergey@yandex.ru>